### PR TITLE
modified makefile with .d files to make it easier with multiple .h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 #---------------------------------Variables---------------------------------#
 
 OBJS_DIR	=	.objs
+DEPS_DIR	=	.deps
 SRCS_DIR	=	sources
 HEADER_DIR	=	includes
-HEADER_FILE = 	minishell.h
 LIBFT		=	./libft/libft.a
 NAME		=	minishell
 OBJS	=	$(patsubst $(SRCS_DIR)%.c, $(OBJS_DIR)%.o, $(SRCS))
+DEPS 	= 	$(OBJS:.o=.d)
 #------------------------------------------------------------------------#
 
 #---------------------------------Sources---------------------------------#
@@ -21,9 +22,9 @@ SRCS =		$(SRCS_DIR)/export.c \
 #---------------------------------Compilation & Linking---------------------------------#
 CC		=	cc
 RM		=	rm -f
-CFLAGS	=	  -g3
-LINKLIBS = -L libft/ -lft
-INCLUDES = -I $(HEADER_DIR) -I libft
+CFLAGS	=	-lreadline -g3 
+LINKLIBS = -L libft/ -lft 
+INCLUDES = -I $(HEADER_DIR) -I libft -MMD -MP
 
 #------------------------------------------------------------------------#
 
@@ -38,13 +39,14 @@ CUT		=	"\033[K"
 
 
 all: $(NAME)
+-include $(DEPS)
 
 $(LIBFT): FORCE
 	@$(MAKE) --no-print-directory -C ./libft
 
 FORCE:
 
-$(OBJS_DIR)/%.o: $(SRCS_DIR)/%.c $(HEADER_DIR)/$(HEADER_FILE)
+$(OBJS_DIR)/%.o: $(SRCS_DIR)/%.c
 	@mkdir -p $(@D)
 	@echo "$(YELLOW)Compiling [$<]$(RESET)"
 	@$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ 
@@ -52,7 +54,7 @@ $(OBJS_DIR)/%.o: $(SRCS_DIR)/%.c $(HEADER_DIR)/$(HEADER_FILE)
 
 $(NAME): $(OBJS) $(LIBFT) Makefile
 	@echo "$(YELLOW)Compiling [$<]$(RESET)"
-	@$(CC) $(OBJS) $(CFLAGS) -lreadline $(INCLUDES) $(LINKLIBS) -o $@ 
+	@$(CC) $(OBJS) $(CFLAGS) $(INCLUDES) $(LINKLIBS) -o $@ 
 	@printf $(UP)$(CUT)
 	@echo "$(GREEN)$(NAME) compiled!$(RESET)"
 


### PR DESCRIPTION
![image](https://github.com/PtitDrogo/ASTERIX-ET-OBELIX-MISSION-MINISHELL/assets/123643348/57d81f1d-905b-431d-b202-e7658e71d2f7)
DEPS makes .d files in the folder already containing the .o files.
![image](https://github.com/PtitDrogo/ASTERIX-ET-OBELIX-MISSION-MINISHELL/assets/123643348/9adb2112-7896-4667-a87d-1db41e5714d2)
Includes deps will make the compile process use the .d files to check for dependancy
![image](https://github.com/PtitDrogo/ASTERIX-ET-OBELIX-MISSION-MINISHELL/assets/123643348/f6e7abf2-38c7-449c-8433-87fc5d1a9123)
-MMD and -MP in a nutshell are needed for that to work
![image](https://github.com/PtitDrogo/ASTERIX-ET-OBELIX-MISSION-MINISHELL/assets/123643348/840a8527-b167-47b3-b00b-8ace99fbe562)
I no longer need to hardcore the dependancy to the one header file when doing this

Now we should be able to use any header file wherever whenever